### PR TITLE
chore: setup seeding

### DIFF
--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -1,11 +1,19 @@
-# Script for populating the database. You can run it as:
-#
-#     mix run priv/repo/seeds.exs
-#
-# Inside the script, you can read and write to any of your
-# repositories directly:
-#
-#     Katana.Repo.insert!(%Katana.SomeSchema{})
-#
-# We recommend using the bang functions (`insert!`, `update!`
-# and so on) as they will fail if something goes wrong.
+defmodule Atomic.Repo.Seeds do
+  @moduledoc """
+  Script for populating the database.
+  You can run it as:
+    $ mix run priv/repo/seeds.exs # or mix ecto.seed
+  """
+  @seeds_dir "priv/repo/seeds"
+
+  def run do
+    [
+      "user.exs"
+    ]
+    |> Enum.each(fn file ->
+      Code.require_file("#{@seeds_dir}/#{file}")
+    end)
+  end
+end
+
+Atomic.Repo.Seeds.run()

--- a/priv/repo/seeds/user.exs
+++ b/priv/repo/seeds/user.exs
@@ -1,0 +1,38 @@
+defmodule Katana.Repo.Seeds.Accounts do
+  @moduledoc """
+  Minimal example of seeding.
+
+  NOTE: THIS SEEDING SERVES ONLY AS A EXAMPLE OF STRUCTURE
+  """
+  alias Katana.Accounts
+  alias Katana.Accounts.User
+  alias Katana.Repo
+
+  def run do
+    case Repo.all(User) do
+      [] ->
+        seed_users()
+
+      _ ->
+        Mix.shell().error("Found users, aborting seeding users.")
+    end
+  end
+
+  defp seed_users do
+    users = [
+      %{name: "Chandler Bing", email: "test@mail.com", password: "Pass1234321!"}
+    ]
+
+    for attrs <- users do
+      case Accounts.register_user(attrs) do
+        {:ok, user} ->
+          Repo.update!(User.confirm_changeset(user))
+
+        {:error, changeset} ->
+          Mix.shell().error(inspect(changeset.errors))
+      end
+    end
+  end
+end
+
+Katana.Repo.Seeds.Accounts.run()


### PR DESCRIPTION
Adds a example seeding script, in this case for users.
Rewrites the `seeds.exs` file to run all the scripts inside the `seeds/` directory