### PR TITLE
chore: adapt to wsl

### DIFF
--- a/config/dev.exs
+++ b/config/dev.exs
@@ -2,10 +2,10 @@ import Config
 
 # Configure your database
 config :katana, Katana.Repo,
-  username: "postgres",
-  password: "postgres",
-  hostname: "localhost",
-  database: "katana_dev",
+  username: System.get_env("DB_USERNAME") || "postgres",
+  password: System.get_env("DB_PASSWORD") || "postgres",
+  hostname: System.get_env("DB_HOST") || "localhost",
+  database: System.get_env("DB_NAME") || "katana_dev",
   port: String.to_integer(System.get_env("DB_PORT") || "5432"),
   stacktrace: true,
   show_sensitive_data_on_connection_error: true,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,3 +9,5 @@ services:
       POSTGRES_HOST: ${DB_HOST:-localhost}
     volumes:
       - /var/lib/postgresql/data
+    ports:
+      - "5432:5432"  # <- allows WSL to connect to localhost:5432

--- a/wsl.yml
+++ b/wsl.yml
@@ -1,0 +1,3 @@
+services:
+  db:
+    # network_mode: "host"


### PR DESCRIPTION
This PR intends to make PostgreSQL (Docker) work on WSL by replacing `network_mode: "host"` (which relies on UNIX sockets) with port mapping (`ports: "5432:5432"`) and adding a `wsl.yml` override so the database can be started on WSL with `docker compose -f docker-compose.yml -f wsl.yml up -d db`.
